### PR TITLE
Use <stdint.h> to fix musl compatibility

### DIFF
--- a/src/ntp.c
+++ b/src/ntp.c
@@ -52,6 +52,7 @@
 #include <netdb.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
@@ -106,11 +107,11 @@ struct ntp_data {
     double		receive;
     double		transmit;
     double		current;
-    u_int64_t	recvck;
+    uint64_t	recvck;
 
     /* Local State */
     double		originate;
-    u_int64_t	xmitck;
+    uint64_t	xmitck;
 };
 
 void	ntp_client(const char *, int, struct timeval *, struct timeval *, int, int, int);
@@ -282,7 +283,7 @@ write_packet(int fd, struct ntp_data *data)
 
     packet[0] = (NTP_VERSION << 3) | (NTP_MODE_CLIENT);
 
-    data->xmitck = (u_int64_t)arc4random() << 32 | arc4random();
+    data->xmitck = (uint64_t)arc4random() << 32 | arc4random();
 
     /*
      * Send out a random 64-bit number as our transmit time.  The NTP
@@ -300,7 +301,7 @@ write_packet(int fd, struct ntp_data *data)
      * the transmit field intelligible.
      */
 
-    *(u_int64_t *)(packet + NTP_TRANSMIT) = data->xmitck;
+    *(uint64_t *)(packet + NTP_TRANSMIT) = data->xmitck;
 
     data->originate = current_time(JAN_1970);
 
@@ -453,7 +454,7 @@ double
 current_time(double offset)
 {
     struct timeval current;
-    u_int64_t t;
+    uint64_t t;
 
     if (gettimeofday(&current, NULL))
         err(1, "Could not get local time of day");

--- a/src/ntpleaps.c
+++ b/src/ntpleaps.c
@@ -45,12 +45,13 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 
 #include "ntpleaps.h"
 
-static u_int64_t *leapsecs;
+static uint64_t *leapsecs;
 static unsigned int leapsecs_num;
 
 
@@ -81,10 +82,10 @@ ntpleaps_init(void)
 }
 
 int
-ntpleaps_sub(u_int64_t *t)
+ntpleaps_sub(uint64_t *t)
 {
     unsigned int i = 0;
-    u_int64_t u;
+    uint64_t u;
     int r = 1;
 
     if (ntpleaps_init() == -1)
@@ -105,10 +106,10 @@ ntpleaps_sub(u_int64_t *t)
     return (r);
 }
 
-u_int32_t
-read_be_dword(u_int8_t *ptr)
+uint32_t
+read_be_dword(uint8_t *ptr)
 {
-    u_int32_t res;
+    uint32_t res;
 
     memcpy(&res, ptr, 4);
     return (ntohl(res));
@@ -120,10 +121,10 @@ ntpleaps_read(void)
 {
     int fd;
     unsigned int r;
-    u_int8_t buf[32];
-    u_int32_t m1, m2, m3;
-    u_int64_t s;
-    u_int64_t *l;
+    uint8_t buf[32];
+    uint32_t m1, m2, m3;
+    uint64_t s;
+    uint64_t *l;
 
     fd = open("/usr/share/zoneinfo/right/UTC", O_RDONLY | O_NDELAY);
     if (fd == -1)
@@ -153,7 +154,7 @@ ntpleaps_read(void)
         close(fd);
         return (-1);
     }
-    if ((l = (u_int64_t *)malloc(r << 3)) == NULL) {
+    if ((l = (uint64_t *)malloc(r << 3)) == NULL) {
         close(fd);
         return (-1);
     }

--- a/src/ntpleaps.h
+++ b/src/ntpleaps.h
@@ -46,11 +46,13 @@
 #ifndef _NTPLEAPS_H
 #define _NTPLEAPS_H
 
+#include <stdint.h>
+
 /* Offset between struct timeval.tv_sec and a tai64_t */
 #define	NTPLEAPS_OFFSET	(4611686018427387914ULL)
 
 /* Hide this ugly value from programmes */
-#define	SEC_TO_TAI64(s)	(NTPLEAPS_OFFSET + (u_int64_t)(s))
+#define	SEC_TO_TAI64(s)	(NTPLEAPS_OFFSET + (uint64_t)(s))
 #define	TAI64_TO_SEC(t)	((t) - NTPLEAPS_OFFSET)
 
 /* Initializes the leap second table. Does not need to be called
@@ -70,6 +72,6 @@ int ntpleaps_read(void);
  * to posix clock tick time.
  * returns 0 on success, -1 on error (time is unchanged), 1 on leap second
  */
-int ntpleaps_sub(u_int64_t *);
+int ntpleaps_sub(uint64_t *);
 
 #endif

--- a/src/rfc868time.c
+++ b/src/rfc868time.c
@@ -50,6 +50,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <err.h>
+#include <stdint.h>
 #include <string.h>
 #include <netdb.h>
 #include <unistd.h>
@@ -68,10 +69,10 @@ rfc868time_client (const char *hostname, int family, struct timeval *new,
 {
     struct addrinfo hints, *res0, *res;
     struct timeval old;
-    u_int32_t tim;	/* RFC 868 states clearly this is an uint32 */
+    uint32_t tim;	/* RFC 868 states clearly this is an uint32 */
     int s;
     int error;
-    u_int64_t td;
+    uint64_t td;
 
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = family;


### PR DESCRIPTION
uint32_t and friends are provided by <stdint.h> and the types
previously being relied on are non-standard, so let's swap.

This fixes building rdate on e.g. musl rather than glibc.

Bug: https://bugs.gentoo.org/832554
Signed-off-by: Sam James <sam@gentoo.org>